### PR TITLE
parse add'l arguments, custom build directory and whether to install

### DIFF
--- a/git-openssl.sh
+++ b/git-openssl.sh
@@ -61,9 +61,7 @@ fi
 dpkg-buildpackage -rfakeroot -b
 
 # Install
-if [[ -z $SKIPTESTS ]]
+if [[ -z $SKIPINSTALL ]]
 then 
   find .. -type f -name "git_*ubuntu*.deb" -exec sudo dpkg -i \{\} \;
 fi
-
-

--- a/git-openssl.sh
+++ b/git-openssl.sh
@@ -35,5 +35,5 @@ fi
 # Build it.
 dpkg-buildpackage -rfakeroot -b
 
-# Install
-find .. -type f -name "git_*ubuntu*.deb" -exec sudo dpkg -i \{\} \;
+# Store for artifact pick up
+find .. -type f -name "git_*ubuntu*.deb" -exec cp -i {} ./ \;

--- a/git-openssl.sh
+++ b/git-openssl.sh
@@ -1,14 +1,41 @@
 #!/usr/bin/env bash
 
-# Clear out all previous attempts
-rm -rf "/tmp/source-git/"
+# Gather command line options
+for i in "$@"
+do 
+  case $i in 
+    -skiptests|--skip-tests) # Skip tests portion of the build
+    SKIPTESTS=YES
+    shift
+    ;;
+    -d=*|--build-dir=*) # Specify the directory to use for the build
+    BUILDDIR="${i#*=}"
+    shift
+    ;;
+    -skipinstall|--skip-install) # Skip dbkg install
+    SKIPINSTALL=YES
+    ;;
+    *)
+    #TODO Maybe define a help section?
+    ;;
+  esac
+done
+
+if [[ $BUILDDIR && -d $BUILDDIR ]]; then
+  :
+else 
+  BUILDDIR="/tmp/source-git"
+  rm -rf "${BUILDDIR}" # Clear out all previous attempts
+  mkdir -p "${BUILDDIR}" 
+fi
+
+echo "BUILD DIRECTORY USED: ${BUILDDIR}" 
+cd "${BUILDDIR}"
 
 # Get the dependencies for git, then get openssl
 sudo apt-get install build-essential fakeroot dpkg-dev -y
 sudo apt-get build-dep git -y
 sudo apt-get install libcurl4-openssl-dev -y
-mkdir -p "/tmp/source-git/"
-cd "/tmp/source-git/"
 if ! grep -q "git-core" /etc/apt/sources.list /etc/apt/sources.list.d/*; then
   sudo apt-add-repository ppa:git-core/ppa
 else
@@ -25,15 +52,18 @@ pwd
 sed -i -- 's/libcurl4-gnutls-dev/libcurl4-openssl-dev/' ./debian/control
 # Compile time, itself, is long. Skips the tests. Do so at your own peril.
 #sed -i -- '/TEST\s*=\s*test/d' ./debian/rules
-if [[ "$@" == "-skiptests" ]]
+if [[ $SKIPTESTS == "YES" ]]
 then
   sed -i -- '/TEST\s*=\s*test/d' ./debian/rules
 fi
 
-
-
 # Build it.
 dpkg-buildpackage -rfakeroot -b
 
-# Store for artifact pick up
-find .. -type f -name "git_*ubuntu*.deb" -exec cp -i {} ./ \;
+# Install
+if [[ -z $SKIPTESTS ]]
+then 
+  find .. -type f -name "git_*ubuntu*.deb" -exec sudo dpkg -i \{\} \;
+fi
+
+


### PR DESCRIPTION
Needed script to be more configurable, wanted several
additional flags to be parsed. Added the following   
- **-skiptests|--skip-tests**
  compatibility for 
                          current skip test flag. 
  Will skip tests. 
- **-d=VALUE|--build-dir=VALUE**
  changes the build directory 
                          for where git will be sourced
                          and compiled. Note the equals
                          sign, any value passed in after
                          the equals will be used as the
                          build directory. Defaults to /tmp/source-git 
  if empty or directory doesn't exist. 
- **-skipinstall|--skip-install**
  flag for whether we should 
                          skip the install on the current
                          system. Useful in case we'd simply
                          want a git-openssl package
