### PR TITLE
Refactored static docker compiler Dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,24 +4,35 @@ ARG CURL_OPTIONS=''
 # no interactions with apt possible
 ENV DEBIAN_FRONTEND=noninteractive
 # update apt
-RUN apt-get update -qq -y --fix-missing;
-# install required packages
+RUN apt-get update -qq -y;
+# Install stuff for git itself
+RUN apt-get install -qq -y --no-install-recommends \
+    zlib1g \
+    libcurl4 \
+    perl \
+    libpcre3 \
+    libexpat1 \
+    liberror-perl \
+    libc6;
+# Install meta-things for building on the end-user's machine
 RUN apt-get install -qq -y --no-install-recommends \
     build-essential \
     autoconf \
     dh-autoreconf \
+    # @see https://help.ubuntu.com/community/CheckInstall
+    checkinstall \
+    curl \
+    # @see https://stedolan.github.io/jq/tutorial/
+    jq;
+# Install dev stuff for git
+RUN apt-get install -qq -y --no-install-recommends \
     libcurl4-openssl-dev \
     tcl-dev \
     gettext \
     asciidoc \
     libexpat1-dev \
     libz-dev \
-    # @see https://help.ubuntu.com/community/CheckInstall
-    checkinstall \
-    # install curl and jq for downloading
-    curl \
-    # @see https://stedolan.github.io/jq/tutorial/
-    jq;
+    libssl-dev;
 # prepare source dir
 RUN mkdir -p /root/src;
 WORKDIR /root/src
@@ -29,23 +40,39 @@ WORKDIR /root/src
 RUN curl ${CURL_OPTIONS} \
         --location \
         --fail \
+        # assuming the top-most tag is the most recent version
         $(curl ${CURL_OPTIONS} --silent --fail 'https://api.github.com/repos/git/git/tags' | jq '.[0].tarball_url' | tr -d '"') \
     | tar xz --strip 1;
 # configure & compile git with OpenSSL
 RUN make configure; \
-    CFLAGS="-static" ./configure --with-openssl; \
+    ./configure --prefix=/usr --with-openssl; \
     make;
 # create debian package
 RUN checkinstall \
+        --default \
         --type=debian \
         --pkgname=git-openssl \
-        --pkgversion=$(./git --version | cut -d " " -f 3);
+        --pkgversion=$(./git --version | cut -d " " -f 3) \
+        --pkgarch=$(dpkg --print-architecture) \
+        --conflicts=git \
+        --requires="libcurl4,zlib1g \(\>= 1:1.2.0\),perl,libpcre3,libexpat1 \(\>= 2.0.1\),liberror-perl,libc6" \
+        --recommends="less,patch,ssh-client,ca-certificates" \
+        make install;
 # move created .deb file to a more scriptable filename
-RUN mv -v ./git-openssl_$(./git --version | cut -d " " -f 3)-1_amd64.deb ./git-openssl.deb;
+RUN cp -v ./git-openssl_$(./git --version | cut -d " " -f 3)-1_$(dpkg --print-architecture).deb /root/git-openssl.deb;
 
 # install package on plain ubuntu
 FROM ubuntu:latest
 COPY --from=git-compiler \
-    /root/src/git-openssl.deb \
+    /root/git-openssl.deb \
     /root/git-openssl.deb
+RUN apt-get update -qq -y; \
+    apt-get install -qq -y --no-install-recommends \
+        libcurl4 \
+        perl \
+        libexpat1 \
+        liberror-perl \
+        ca-certificates; \
+    apt-get clean;
 RUN dpkg -i /root/git-openssl.deb
+ENTRYPOINT [ "git" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,51 @@
-FROM golang:1.13.4 as git-compiler-helper
-ADD ./git-compiler-helper /root/git-compiler-helper
-WORKDIR /root/git-compiler-helper
-RUN go get -d ./...
-RUN go build -o /root/git-latest-url-finder.run .
-
 FROM ubuntu:latest as git-compiler
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update
-RUN apt-get install build-essential autoconf dh-autoreconf -y
-RUN apt-get install libcurl4-openssl-dev tcl-dev gettext \
-  asciidoc libexpat1-dev libz-dev -y
-RUN apt-get install curl -y
-RUN mkdir -p /root/src
+# Optional curl options like --insecure in case you're behind a corporate proxy.
+ARG CURL_OPTIONS=''
+# no interactions with apt possible
+ENV DEBIAN_FRONTEND=noninteractive
+# update apt
+RUN apt-get update -qq -y --fix-missing;
+# install required packages
+RUN apt-get install -qq -y --no-install-recommends \
+    build-essential \
+    autoconf \
+    dh-autoreconf \
+    libcurl4-openssl-dev \
+    tcl-dev \
+    gettext \
+    asciidoc \
+    libexpat1-dev \
+    libz-dev \
+    # @see https://help.ubuntu.com/community/CheckInstall
+    checkinstall \
+    # install curl and jq for downloading
+    curl \
+    # @see https://stedolan.github.io/jq/tutorial/
+    jq;
+# prepare source dir
+RUN mkdir -p /root/src;
 WORKDIR /root/src
-COPY --from=git-compiler-helper \
-  /root/git-latest-url-finder.run \
-  /root/git-latest-url-finder.run
-RUN /root/git-latest-url-finder.run > git-tar-url.txt && \
-  echo "$(cat git-tar-url.txt)" && \
-  curl -L --retry 5 --url "$(cat git-tar-url.txt)" --output "git-source.tar.gz" && \
-  tar -xf "git-source.tar.gz" --strip 1
-RUN make configure
-RUN CFLAGS="-static" ./configure --with-openssl
-RUN make
-RUN make install
-ENTRYPOINT [ "git" ]
+# download & extract source tar
+RUN curl ${CURL_OPTIONS} \
+        --location \
+        --fail \
+        $(curl ${CURL_OPTIONS} --silent --fail 'https://api.github.com/repos/git/git/tags' | jq '.[0].tarball_url' | tr -d '"') \
+    | tar xz --strip 1;
+# configure & compile git with OpenSSL
+RUN make configure; \
+    CFLAGS="-static" ./configure --with-openssl; \
+    make;
+# create debian package
+RUN checkinstall \
+        --type=debian \
+        --pkgname=git-openssl \
+        --pkgversion=$(./git --version | cut -d " " -f 3);
+# move created .deb file to a more scriptable filename
+RUN mv -v ./git-openssl_$(./git --version | cut -d " " -f 3)-1_amd64.deb ./git-openssl.deb;
+
+# install package on plain ubuntu
+FROM ubuntu:latest
+COPY --from=git-compiler \
+    /root/src/git-openssl.deb \
+    /root/git-openssl.deb
+RUN dpkg -i /root/git-openssl.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,15 +49,15 @@ RUN make configure; \
     make;
 # create debian package
 RUN checkinstall \
-        --default \
-        --type=debian \
-        --pkgname=git-openssl \
-        --pkgversion=$(./git --version | cut -d " " -f 3) \
-        --pkgarch=$(dpkg --print-architecture) \
-        --conflicts=git \
-        --requires="libcurl4,zlib1g \(\>= 1:1.2.0\),perl,libpcre3,libexpat1 \(\>= 2.0.1\),liberror-perl,libc6" \
-        --recommends="less,patch,ssh-client,ca-certificates" \
-        make install;
+    --default \
+    --type=debian \
+    --pkgname=git-openssl \
+    --pkgversion=$(./git --version | cut -d " " -f 3) \
+    --pkgarch=$(dpkg --print-architecture) \
+    --conflicts=git \
+    --requires="libcurl4,zlib1g \(\>= 1:1.2.0\),perl,libpcre3,libexpat1 \(\>= 2.0.1\),liberror-perl,libc6" \
+    --recommends="less,patch,ssh-client,ca-certificates" \
+    make install;
 # move created .deb file to a more scriptable filename
 RUN cp -v ./git-openssl_$(./git --version | cut -d " " -f 3)-1_$(dpkg --print-architecture).deb /root/git-openssl.deb;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,8 @@ COPY --from=git-compiler \
     /root/git-openssl.deb \
     /root/git-openssl.deb
 # install package dependencies
-RUN apt-get update -qq -y; \
+RUN set -xe; \
+    apt-get update -qq -y; \
     apt-get install -qq -y --no-install-recommends \
         libcurl4 \
         perl \

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,16 +63,26 @@ RUN cp -v ./git-openssl_$(./git --version | cut -d " " -f 3)-1_$(dpkg --print-ar
 
 # install package on plain ubuntu
 FROM ubuntu:latest
+# copy package from temporary image
 COPY --from=git-compiler \
     /root/git-openssl.deb \
     /root/git-openssl.deb
+# install package dependencies
 RUN apt-get update -qq -y; \
     apt-get install -qq -y --no-install-recommends \
         libcurl4 \
         perl \
         libexpat1 \
         liberror-perl \
-        ca-certificates; \
-    apt-get clean;
-RUN dpkg -i /root/git-openssl.deb
+        ca-certificates \
+        less \
+        patch \
+        ssh-client; \
+    apt-get clean; \
+    # install package
+    dpkg -i /root/git-openssl.deb; \
+    # create git config files
+    touch /root/.gitconfig /root/.git-credentials /etc/skel/.gitconfig /etc/skel/.git-credentials; \
+    # create 10 user- and group-IDs in case this image is run without privileges
+    bash -c 'for i in {1000..1010}; do groupadd -g ${i} -o "group${i}"; useradd -m -u ${i} -g ${i} -s /usr/bin/bash "user${i}"; done'
 ENTRYPOINT [ "git" ]


### PR DESCRIPTION
I refactored the docker compiler:
- Query GitHub API (curl + jq) to get the latest git tag, so there is no need for GO.
- Installed requirements according to the original git package.
- Use checkinstall to create an installable .deb package which in turn is installed on a clean ubuntu image.

The disadvantage of this docker image is that when run with a different user than `root`, git will have problems storing config and credentials because `//` is assumed as home directory.

Example build call: `docker build --pull --tag git:latest `

Example run call: `docker run --init --rm --tty --interactive --user $(id -u):$(id -g) --volume $(pwd):/app --workdir /app git:latest clone https://github.com/git/git.git`