### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ fatal: unable to access 'http://you@path.to/arbitrary/repository.git': gnutls_ha
 ```
 The only way to resolve this is by re-compiling git with `openssl` instead of `gnutls`.
 
-This shellscript does that by downloading the source for git, switching it to `openssl` and and then building it. If you are using a managed version of git (eg: through ubuntu's package manager) you will have to re-run the script every time you recieve an updated version of git because the managed version will overwrite your compiled version (it's honestly better to just uninstall it first, otherwise you're going to be fighting with `apt` with every git update)
+This shellscript does that by downloading the source for git, switching it to `openssl` and then building it. If you are using a managed version of git (eg: through ubuntu's package manager) you will have to re-run the script every time you receive an updated version of git because the managed version will overwrite your compiled version (it's honestly better to just uninstall it first, otherwise you're going to be fighting with `apt` with every git update)


### PR DESCRIPTION
## Summary
- remove a duplicated `and` in the README description
- correct `recieve` to `receive`

## Validation
- `rg -n "recieve|receive|and and|and then building" README.md`
- `git diff --check`

No code changes.